### PR TITLE
match API updates, param and typo fixes

### DIFF
--- a/example.js
+++ b/example.js
@@ -1,6 +1,6 @@
 var FootballData = require('./lib.js');
 var fd = FootballData('');
-fd.getLeagugeFixtures(424).then(function(res) {
+fd.getLeagueFixtures(424).then(function(res) {
   var fixtures = res;
   console.log(fixtures.fixtures[0].homeTeamName + "vs" + fixtures.fixtures[0].awayTeamName);
 }).catch(function(err) {

--- a/lib.js
+++ b/lib.js
@@ -17,24 +17,28 @@ FootballData.prototype.getRequest = function (path) {
   };
 }
 
-FootballData.prototype.getSeasons = function () {
-  return rp(this.getRequest('/v1/soccerseasons/'));
+FootballData.prototype.getCompetitions = function (season) {
+  var config = this.getRequest('/v1/competitions/');
+  if (season) {
+    config.qs = {season: season};
+  }
+  return rp(config);
 }
 
-FootballData.prototype.getTeamsInSeason = function (seasonId) {
-  return rp(this.getRequest(`/v1/soccerseasons/${seasonId}/teams`));
+FootballData.prototype.getTeamsInCompetition = function (competitionId) {
+  return rp(this.getRequest(`/v1/competitions/${competitionId}/teams`));
 }
 
-FootballData.prototype.getLeagueTable = function (seasonId) {
-  return rp(this.getRequest(`/v1/soccerseasons/${seasonId}/leagueTable`));
+FootballData.prototype.getLeagueTable = function (competitionId) {
+  return rp(this.getRequest(`/v1/competitions/${competitionId}/leagueTable`));
 }
 
-FootballData.prototype.getLeagugeFixtures = function (seasonId) {
-  return rp(this.getRequest(`/v1/soccerseasons/${seasonId}/fixtures`));
+FootballData.prototype.getLeagueFixtures = function (competitionId) {
+  return rp(this.getRequest(`/v1/competitions/${competitionId}/fixtures`));
 }
 
-FootballData.prototype.getLeagugeFixturesInTimeFrame = function (seasonId, timeFrame) {
-  var config = this.getRequest(`/v1/soccerseasons/${seasonId}/fixtures`);
+FootballData.prototype.getLeagueFixturesInTimeFrame = function (competitionId, timeFrame) {
+  var config = this.getRequest(`/v1/competitions/${competitionId}/fixtures`);
   config.qs = {timeFrame: timeFrame}
   return rp(config);
 }
@@ -44,20 +48,20 @@ FootballData.prototype.getFixtures = function () {
 }
 
 FootballData.prototype.getFixture = function (fixtureId) {
-  return rp(this.getRequest(`/v1/fixtures/${seasonId}`));
+  return rp(this.getRequest(`/v1/fixtures/${fixtureId}`));
 }
 
 FootballData.prototype.getTeam = function (teamId) {
-  return rp(this.getRequest(`/v1/teams/${seasonId}`));
+  return rp(this.getRequest(`/v1/teams/${teamId}`));
 }
 
 FootballData.prototype.getTeamPlayers = function (teamId) {
-  return rp(this.getRequest(`/v1/teams/${seasonId}/players`));
+  return rp(this.getRequest(`/v1/teams/${teamId}/players`));
 }
 
 
 FootballData.prototype.getTeamFixtures = function (teamId) {
-  return rp(this.getRequest(`/v1/teams/${seasonId}/fixtures`));
+  return rp(this.getRequest(`/v1/teams/${teamId}/fixtures`));
 }
 
 module.exports = FootballData;


### PR DESCRIPTION
- updated API request in V1 from "seasons" to "competitions" to match API change
- updated method from getSeasons() to getCompetitions() to match API change
- updated method from getTeamsInSeason() to getTeamsInCompetition() to match API change
- added seasons filter to getCompetitions()
- updated spelling of getLeagueFixtures
- changed parameter usage for getFixture(), getTeam(), getTeamPlayers(), getTeamFixtures()

Thanks for the nice wrapper
